### PR TITLE
co2 daily and weekly max level tracking and display

### DIFF
--- a/adanet-co2-monitor.ino
+++ b/adanet-co2-monitor.ino
@@ -75,7 +75,7 @@ typedef enum
 static int8_t tempUnits;
 // number of updates per day 60s * 60min * 24hrs = 86400
 static constexpr int32_t UPDATES_PER_DAY = (86400 / DISPLAY_WAIT);
-static constexpr int32_t UPDATES_PER_WEEK = UPDATES_PER_DAY * 1;
+static constexpr int32_t UPDATES_PER_WEEK = UPDATES_PER_DAY * 7;
 RTC_DATA_ATTR static uint16_t co2HistoryFifo[UPDATES_PER_WEEK];
 RTC_DATA_ATTR static uint16_t co2HistoryHead = 0;
 RTC_DATA_ATTR static uint16_t co2HistorySize = 0;

--- a/adanet-co2-monitor.ino
+++ b/adanet-co2-monitor.ino
@@ -54,6 +54,8 @@ static Adafruit_DPS310 dps;
 static uint32_t error;
 static char message[MESSAGE_SIZE];
 static Preferences pref;
+static constexpr uint8_t CO2_VAL_STRING_LEN = 20;
+static char formattedCo2Str[CO2_VAL_STRING_LEN];
 
 typedef enum
 {
@@ -154,6 +156,16 @@ void computeCo2Max(uint16_t *const dayMax, uint16_t *const weekMax)
     {
       *weekMax = co2HistoryRead(i);
     }
+  }
+}
+
+void formatCo2(char *str, uint16_t val){
+  if(val < 9999)
+  {
+    snprintf(str, CO2_VAL_STRING_LEN, "%u", val);
+  }
+  else{
+    snprintf(str, CO2_VAL_STRING_LEN, "%.0fK", static_cast<float>(val) / 1000.f);
   }
 }
 
@@ -351,13 +363,16 @@ void setup()
     printfAligned(HEADER_SIZE, ALIGN_RIGHT, headerY, EPD_BLACK, "%5.1f%%", humidity);
 
     uint16_t co2Color = co2 >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    printfAligned(BODY_SIZE, ALIGN_CENTER, bodyY, co2Color, "%u", co2);
+    formatCo2(formattedCo2Str, co2);
+    printfAligned(BODY_SIZE, ALIGN_CENTER, bodyY, co2Color, "%s", formattedCo2Str);
 
     co2Color = co2DayMax >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    printfAligned(MAXVAL_SIZE, ALIGN_LEFT, maxValueY, co2Color, "%u", co2DayMax);
+    formatCo2(formattedCo2Str,co2DayMax);
+    printfAligned(MAXVAL_SIZE, ALIGN_LEFT, maxValueY, co2Color, "%s", formattedCo2Str);
     
     co2Color = co2WeekMax >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    printfAligned(MAXVAL_SIZE, ALIGN_RIGHT, maxValueY, co2Color, "%u", co2WeekMax);
+    formatCo2(formattedCo2Str, co2WeekMax);
+    printfAligned(MAXVAL_SIZE, ALIGN_RIGHT, maxValueY, co2Color, "%s", formattedCo2Str);
 
     printfAligned(MAXLBL_SIZE, ALIGN_LEFT, maxLabelY, EPD_BLACK, "%s", "max/day");
     printfAligned(MAXLBL_SIZE, ALIGN_RIGHT, maxLabelY, EPD_BLACK, "%s", "max/week");

--- a/adanet-co2-monitor.ino
+++ b/adanet-co2-monitor.ino
@@ -79,9 +79,8 @@ typedef enum
 
 static int8_t tempUnits;
 
-RTC_DATA_ATTR static uint16_t co2HistoryFifo[UPDATES_PER_WEEK];
+RTC_DATA_ATTR static uint16_t co2HistoryFifo[UPDATES_PER_WEEK] = {0};
 RTC_DATA_ATTR static uint16_t co2HistoryHead = 0;
-RTC_DATA_ATTR static uint16_t co2HistorySize = 0;
 
 void checkSCD4xError(const uint16_t scd4xError)
 {
@@ -125,11 +124,6 @@ void co2HistoryAdd(const uint16_t co2)
 {
   co2HistoryFifo[co2HistoryHead] = co2;
   ++co2HistoryHead %= UPDATES_PER_WEEK;
-
-  if (++co2HistorySize > UPDATES_PER_WEEK) 
-  {
-    co2HistorySize = UPDATES_PER_WEEK;
-  }
 }
 
 uint16_t co2HistoryRead(const uint16_t index) 
@@ -153,7 +147,7 @@ void computeCo2Max(uint16_t& dayMax, uint16_t& weekMax)
   dayMax = 0;
   weekMax = 0;
 
-  for (uint16_t i = 0; i < co2HistorySize; i++) 
+  for (uint16_t i = 0; i < UPDATES_PER_WEEK; i++) 
   {
     if (i < UPDATES_PER_DAY)
     {

--- a/adanet-co2-monitor.ino
+++ b/adanet-co2-monitor.ino
@@ -159,13 +159,14 @@ void computeCo2Max(uint16_t *const dayMax, uint16_t *const weekMax)
   }
 }
 
-void formatCo2(char *str, uint16_t val){
-  if(val < 9999)
+void formatCo2(const uint16_t primaryCo2Val, const uint16_t secondaryCo2Val, char *str){
+  if((primaryCo2Val > 9999 && secondaryCo2Val > 999) || (primaryCo2Val > 999 && secondaryCo2Val > 9999)) 
   {
-    snprintf(str, CO2_VAL_STRING_LEN, "%u", val);
+    snprintf(str, CO2_VAL_STRING_LEN, "%.0fK", static_cast<float>(secondaryCo2Val) / 1000.f);
   }
-  else{
-    snprintf(str, CO2_VAL_STRING_LEN, "%.0fK", static_cast<float>(val) / 1000.f);
+  else
+  {
+    snprintf(str, CO2_VAL_STRING_LEN, "%u", secondaryCo2Val);
   }
 }
 
@@ -363,19 +364,20 @@ void setup()
     printfAligned(HEADER_SIZE, ALIGN_RIGHT, headerY, EPD_BLACK, "%5.1f%%", humidity);
 
     uint16_t co2Color = co2 >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    formatCo2(formattedCo2Str, co2);
-    printfAligned(BODY_SIZE, ALIGN_CENTER, bodyY, co2Color, "%s", formattedCo2Str);
+    printfAligned(BODY_SIZE, ALIGN_CENTER, bodyY, co2Color, "%u", co2);
 
     co2Color = co2DayMax >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    formatCo2(formattedCo2Str,co2DayMax);
+    formatCo2(co2, co2DayMax, formattedCo2Str);
     printfAligned(MAXVAL_SIZE, ALIGN_LEFT, maxValueY, co2Color, "%s", formattedCo2Str);
-    
+  
     co2Color = co2WeekMax >= CO2_LIMIT ? EPD_RED : EPD_BLACK;
-    formatCo2(formattedCo2Str, co2WeekMax);
+    formatCo2(co2, co2WeekMax, formattedCo2Str);
     printfAligned(MAXVAL_SIZE, ALIGN_RIGHT, maxValueY, co2Color, "%s", formattedCo2Str);
 
-    printfAligned(MAXLBL_SIZE, ALIGN_LEFT, maxLabelY, EPD_BLACK, "%s", "max/day");
-    printfAligned(MAXLBL_SIZE, ALIGN_RIGHT, maxLabelY, EPD_BLACK, "%s", "max/week");
+    printfAligned(MAXLBL_SIZE, ALIGN_LEFT, maxLabelY, EPD_BLACK, "%s", "max/");
+    printfAligned(MAXLBL_SIZE, ALIGN_LEFT, maxLabelY + MAXLBL_SIZE * CHAR_HEIGHT, EPD_BLACK, "%s", "day");
+    printfAligned(MAXLBL_SIZE, ALIGN_RIGHT, maxLabelY, EPD_BLACK, "%s", "max/");
+    printfAligned(MAXLBL_SIZE, ALIGN_RIGHT, maxLabelY + MAXLBL_SIZE * CHAR_HEIGHT, EPD_BLACK, "%s", "week");
 
     const uint16_t battColor = batt < BATT_LIMIT ? EPD_RED : EPD_BLACK;
     const int16_t x0 = FOOTER_SIZE * CHAR_WIDTH / 2;

--- a/adanet-co2-monitor.ino
+++ b/adanet-co2-monitor.ino
@@ -7,7 +7,6 @@
 #include <Adafruit_LC709203F.h>
 #include <Adafruit_ThinkInk.h>
 #include <Preferences.h>
-#include <CircularBuffer.h>
 #include <SensirionI2CScd4x.h>
 #include <Wire.h>
 


### PR DESCRIPTION
The co2 history is kept in a static fifo located in a special RTC memory space which remains powered on (unlike the main memory which is powered down) during deep sleep. See [this](https://savjee.be/videos/programming-esp32-with-arduino/using-rtc-memory/) for more info.

Here is what the display looks like:

![co2 display normal](https://user-images.githubusercontent.com/24885427/200097277-c42067de-e16f-459f-81f8-7e768f41d705.png)

The "main" co2 reading is given display priority -- the max values will shrink in size by reducing the number of sig figs (displaying in thousands of ppm) as needed. For example:

![co2 display large](https://user-images.githubusercontent.com/24885427/200097226-f98f0017-3d37-4dfe-9c7e-e5091d2012c8.png)



